### PR TITLE
Fix/v3 incentives

### DIFF
--- a/config/arbitrum-v3.json
+++ b/config/arbitrum-v3.json
@@ -3,5 +3,7 @@
   "AaveOracleAddress": "0xb56c2F0B653B2e0b10C9b928C8580Ac5Df02C7C7",
   "AaveOracleStartBlock": 7740000,
   "PoolAddressesProviderRegistryAddress": "0x770ef9f4fe897e59daCc474EF11238303F9552b6",
-  "PoolAddressesProviderRegistryStartBlock": 7736400
+  "PoolAddressesProviderRegistryStartBlock": 7736400,
+  "RewardsControllerAddress": "0x929EC64c34a17401F460460D4B9390518E5B473e",
+  "RewardsControllerStartBlock": 7940843
 }

--- a/config/avalanche-v3.json
+++ b/config/avalanche-v3.json
@@ -3,5 +3,7 @@
   "AaveOracleAddress": "0xEBd36016B3eD09D4693Ed4251c67Bd858c3c7C9C",
   "AaveOracleStartBlock": 11970000,
   "PoolAddressesProviderRegistryAddress": "0x770ef9f4fe897e59daCc474EF11238303F9552b6",
-  "PoolAddressesProviderRegistryStartBlock": 11970000
+  "PoolAddressesProviderRegistryStartBlock": 11970000,
+  "RewardsControllerAddress": "0x929EC64c34a17401F460460D4B9390518E5B473e",
+  "RewardsControllerStartBlock": 12143958
 }

--- a/config/fantom-v3.json
+++ b/config/fantom-v3.json
@@ -3,5 +3,7 @@
   "AaveOracleAddress": "0xfd6f3c1845604C8AE6c6E402ad17fb9885160754",
   "AaveOracleStartBlock": 33140000,
   "PoolAddressesProviderRegistryAddress": "0x770ef9f4fe897e59daCc474EF11238303F9552b6",
-  "PoolAddressesProviderRegistryStartBlock": 33130000
+  "PoolAddressesProviderRegistryStartBlock": 33130000,
+  "RewardsControllerAddress": "0x929EC64c34a17401F460460D4B9390518E5B473e",
+  "RewardsControllerStartBlock": 33496948
 }

--- a/config/optimism-v3.json
+++ b/config/optimism-v3.json
@@ -3,5 +3,7 @@
   "AaveOracleAddress": "0xD81eb3728a631871a7eBBaD631b5f424909f0c77",
   "AaveOracleStartBlock": 4365670,
   "PoolAddressesProviderRegistryAddress": "0x770ef9f4fe897e59daCc474EF11238303F9552b6",
-  "PoolAddressesProviderRegistryStartBlock": 4364790
+  "PoolAddressesProviderRegistryStartBlock": 4364790,
+  "RewardsControllerAddress": "0x929EC64c34a17401F460460D4B9390518E5B473e",
+  "RewardsControllerStartBlock": 4468687
 }

--- a/config/polygon-v3.json
+++ b/config/polygon-v3.json
@@ -3,5 +3,7 @@
   "AaveOracleAddress": "0xb023e699F5a33916Ea823A16485e259257cA8Bd1",
   "AaveOracleStartBlock": 25825990,
   "PoolAddressesProviderRegistryAddress": "0x770ef9f4fe897e59daCc474EF11238303F9552b6",
-  "PoolAddressesProviderRegistryStartBlock": 25824300
+  "PoolAddressesProviderRegistryStartBlock": 25824300,
+  "RewardsControllerAddress": "0x929EC64c34a17401F460460D4B9390518E5B473e",
+  "RewardsControllerStartBlock": 25970800
 }

--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -121,7 +121,7 @@ type SubToken @entity {
   tokenContractImpl: Bytes
   underlyingAssetAddress: Bytes!
   underlyingAssetDecimals: Int!
-  rewards: [Rewards!]! @derivedFrom(field: "asset")
+  rewards: [Reward!]! @derivedFrom(field: "asset")
 }
 
 type Referrer @entity {
@@ -409,7 +409,7 @@ type RewardFeedOracle @entity {
   updatedAt: Int!
 }
 
-type Rewards @entity {
+type Reward @entity {
   """
   address of ic:asset:reward
   """
@@ -428,14 +428,14 @@ type Rewards @entity {
   updatedAt: Int!
 }
 
-type UserRewards @entity {
+type UserReward @entity {
   """
   id: ic:asset:reward:user
   """
   id: ID!
   user: User!
   index: BigInt!
-  reward: Rewards!
+  reward: Reward!
   createdAt: Int!
   updatedAt: Int!
 }
@@ -445,7 +445,7 @@ type RewardsController @entity {
   address of the incentives controller
   """
   id: ID!
-  rewards: [Rewards!]! @derivedFrom(field: "rewardsController")
+  rewards: [Reward!]! @derivedFrom(field: "rewardsController")
   rewardedActions: [RewardedAction!]! @derivedFrom(field: "rewardsController")
   claimIncentives: [ClaimRewardsCall!]! @derivedFrom(field: "rewardsController")
 }
@@ -729,7 +729,7 @@ type User @entity {
   unclaimedRewards: BigInt!
   lifetimeRewards: BigInt!
   rewardsLastUpdated: Int!
-  rewards: [UserRewards!]! @derivedFrom(field: "user")
+  rewards: [UserReward!]! @derivedFrom(field: "user")
 
   #emode
   eModeCategoryId: EModeCategory

--- a/src/mapping/incentives-controller/v3.ts
+++ b/src/mapping/incentives-controller/v3.ts
@@ -4,17 +4,28 @@ import {
   RewardsClaimed,
   RewardOracleUpdated,
   RewardsController as RewardsControllerContract,
-} from '../../../generated/templates/RewardsController/RewardsController';
+  EmissionManagerUpdated,
+} from '../../../generated/RewardsController/RewardsController';
 import {
   ClaimRewardsCall,
   RewardedAction,
   RewardFeedOracle,
   Rewards,
   UserRewards,
+  RewardsController as RewardsControllerEntity,
 } from '../../../generated/schema';
 import { getOrInitUser } from '../../helpers/v3/initializers';
 import { getHistoryEntityId } from '../../utils/id-generation';
-import { IERC20Detailed } from '../../../generated/templates/RewardsController/IERC20Detailed';
+import { IERC20Detailed } from '../../../generated/RewardsController/IERC20Detailed';
+
+export function handleEmissionManagerUpdated(event: EmissionManagerUpdated): void {
+  const rewardsController = event.address;
+  let iController = RewardsControllerEntity.load(rewardsController.toHexString());
+  if (!iController) {
+    iController = new RewardsControllerEntity(rewardsController.toHexString());
+    iController.save();
+  }
+}
 
 export function handleAssetConfigUpdated(event: AssetConfigUpdated): void {
   let emissionsPerSecond = event.params.newEmission;
@@ -23,6 +34,12 @@ export function handleAssetConfigUpdated(event: AssetConfigUpdated): void {
   let reward = event.params.reward;
   let distributionEnd = event.params.newDistributionEnd;
   let rewardsController = event.address;
+
+  let iController = RewardsControllerEntity.load(rewardsController.toHexString());
+  if (!iController) {
+    iController = new RewardsControllerEntity(rewardsController.toHexString());
+    iController.save();
+  }
 
   //  update rewards configurations
   let rewardIncentiveId =

--- a/src/mapping/incentives-controller/v3.ts
+++ b/src/mapping/incentives-controller/v3.ts
@@ -10,8 +10,8 @@ import {
   ClaimRewardsCall,
   RewardedAction,
   RewardFeedOracle,
-  Rewards,
-  UserRewards,
+  Reward,
+  UserReward,
   RewardsController as RewardsControllerEntity,
 } from '../../../generated/schema';
 import { getOrInitUser } from '../../helpers/v3/initializers';
@@ -45,9 +45,9 @@ export function handleAssetConfigUpdated(event: AssetConfigUpdated): void {
   let rewardIncentiveId =
     rewardsController.toHexString() + ':' + asset.toHexString() + ':' + reward.toHexString();
 
-  let rewardIncentive = Rewards.load(rewardIncentiveId);
+  let rewardIncentive = Reward.load(rewardIncentiveId);
   if (!rewardIncentive) {
-    rewardIncentive = new Rewards(rewardIncentiveId);
+    rewardIncentive = new Reward(rewardIncentiveId);
     rewardIncentive.rewardToken = reward;
     rewardIncentive.asset = asset.toHexString();
     rewardIncentive.rewardsController = rewardsController.toHexString();
@@ -99,7 +99,7 @@ export function handleAccrued(event: Accrued): void {
 
   let rewardId =
     rewardsController.toHexString() + ':' + asset.toHexString() + ':' + reward.toHexString();
-  let rewardIncentive = Rewards.load(rewardId);
+  let rewardIncentive = Reward.load(rewardId);
   if (rewardIncentive) {
     rewardIncentive.index = assetIndex;
     rewardIncentive.updatedAt = blockTimestamp;
@@ -107,9 +107,9 @@ export function handleAccrued(event: Accrued): void {
   }
 
   let userRewardsId = rewardId + ':' + userAddress.toHexString();
-  let userReward = UserRewards.load(userRewardsId);
+  let userReward = UserReward.load(userRewardsId);
   if (!userReward) {
-    userReward = new UserRewards(userRewardsId);
+    userReward = new UserReward(userRewardsId);
     userReward.reward = rewardId;
     userReward.createdAt = blockTimestamp;
     userReward.user = userAddress.toHexString();

--- a/src/mapping/tokenization/initialization-v3.ts
+++ b/src/mapping/tokenization/initialization-v3.ts
@@ -1,15 +1,9 @@
 import { Initialized as ATokenInitialized } from '../../../generated/templates/AToken/AToken';
 import { Initialized as VTokenInitialized } from '../../../generated/templates/VariableDebtToken/VariableDebtToken';
 import { Initialized as STokenInitialized } from '../../../generated/templates/StableDebtToken/StableDebtToken';
-import { RewardsController } from '../../../generated/templates';
 
 import { Address, log } from '@graphprotocol/graph-ts';
-import { zeroAddress } from '../../utils/converters';
-import {
-  ContractToPoolMapping,
-  RewardsController as RewardsControllerEntity,
-  MapAssetPool,
-} from '../../../generated/schema';
+import { ContractToPoolMapping, MapAssetPool } from '../../../generated/schema';
 export {
   handleATokenBurn,
   handleATokenMint,
@@ -22,28 +16,7 @@ export {
   handleVariableTokenBorrowAllowanceDelegated,
 } from './tokenization-v3';
 
-function createIncentivesController(
-  asset: Address,
-  incentivesController: Address,
-  underlyingAsset: Address,
-  pool: Address
-): void {
-  if (incentivesController == zeroAddress()) {
-    log.warning('Incentives controller is 0x0 for asset: {} | underlyingasset: {} | pool: {}', [
-      asset.toHexString(),
-      underlyingAsset.toHexString(),
-      pool.toHexString(),
-    ]);
-    return;
-  }
-
-  let iController = RewardsControllerEntity.load(incentivesController.toHexString());
-  if (!iController) {
-    iController = new RewardsControllerEntity(incentivesController.toHexString());
-    iController.save();
-    RewardsController.create(incentivesController);
-  }
-
+function initializeToken(asset: Address, underlyingAsset: Address, pool: Address): void {
   let poolAddressProvider = ContractToPoolMapping.load(pool.toHexString());
   if (poolAddressProvider != null) {
     // save asset pool mapping
@@ -66,28 +39,13 @@ function createIncentivesController(
 
 export function handleATokenInitialized(event: ATokenInitialized): void {
   log.error('asset: {}', [event.address.toHexString()]);
-  createIncentivesController(
-    event.address,
-    event.params.incentivesController,
-    event.params.underlyingAsset,
-    event.params.pool
-  );
+  initializeToken(event.address, event.params.underlyingAsset, event.params.pool);
 }
 
 export function handleSTokenInitialized(event: STokenInitialized): void {
-  createIncentivesController(
-    event.address,
-    event.params.incentivesController,
-    event.params.underlyingAsset,
-    event.params.pool
-  );
+  initializeToken(event.address, event.params.underlyingAsset, event.params.pool);
 }
 
 export function handleVTokenInitialized(event: VTokenInitialized): void {
-  createIncentivesController(
-    event.address,
-    event.params.incentivesController,
-    event.params.underlyingAsset,
-    event.params.pool
-  );
+  initializeToken(event.address, event.params.underlyingAsset, event.params.pool);
 }

--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -213,17 +213,14 @@ function tokenMint(event: ethereum.Event, onBehalf: Address, value: BigInt, inde
 }
 
 export function handleATokenBurn(event: ATokenBurn): void {
-  log.error('Burn ---------------------------------', []);
   tokenBurn(event, event.params.from, event.params.value, event.params.index);
 }
 
 export function handleATokenMint(event: ATokenMint): void {
-  log.error('Mint ---------------------------------', []);
   tokenMint(event, event.params.onBehalfOf, event.params.value, event.params.index);
 }
 
 export function handleBalanceTransfer(event: BalanceTransfer): void {
-  log.error('Transfer ---------------------------------', []);
   tokenBurn(event, event.params.from, event.params.value, event.params.index);
   tokenMint(event, event.params.to, event.params.value, event.params.index);
 

--- a/templates/v3.subgraph.template.yaml
+++ b/templates/v3.subgraph.template.yaml
@@ -125,7 +125,7 @@ dataSources:
         - event: AssetConfigUpdated(indexed address,indexed address,uint256,uint256,uint256,uint256,uint256)
           handler: handleAssetConfigUpdated
         - event: Accrued(indexed address,indexed address,indexed address,uint256,uint256,uint256)
-          handler: handleRewardsAccrued
+          handler: handleAccrued
         - event: RewardsClaimed(indexed address,indexed address,indexed address,address,uint256)
           handler: handleRewardsClaimed
         - event: RewardOracleUpdated(indexed address,indexed address)

--- a/templates/v3.subgraph.template.yaml
+++ b/templates/v3.subgraph.template.yaml
@@ -98,11 +98,6 @@ dataSources:
         # - event: OwnershipTransferred(indexed address,indexed address)
         #   handler: handleOwnershipTransferred
       file: src/mapping/address-provider-registry/v3.ts
-
-  # --------------------------------------
-  #
-  # --------------------------------------
-templates:
   # --------------------------------------
   #            REWARDS
   # --------------------------------------
@@ -110,7 +105,9 @@ templates:
     name: RewardsController
     network: {{network}}
     source:
+      address: '{{RewardsControllerAddress}}'
       abi: RewardsController
+      startBlock: {{RewardsControllerStartBlock}}
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.6
@@ -133,7 +130,13 @@ templates:
           handler: handleRewardsClaimed
         - event: RewardOracleUpdated(indexed address,indexed address)
           handler: handleRewardOracleUpdated
+        - event: EmissionManagerUpdated(indexed address,indexed address)
+          handler: handleEmissionManagerUpdated
       file: src/mapping/incentives-controller/v3.ts
+  # --------------------------------------
+  #
+  # --------------------------------------
+templates:
   # --------------------------------------
   #      ORACLES / PRICE PROVIDERS
   # --------------------------------------


### PR DESCRIPTION
Currently, incentives data is missing for V3 markets. The correct incentives controller address is set in [this function](https://github.com/aave/aave-v3-core/blob/8e2813a8a1da23dc997f36edfb65937e27307571/contracts/protocol/tokenization/base/IncentivizedERC20.sol#L122), which doesn't emit an event. To fix this, the RewardsController entity is moved from template->dataSources, the addresses are added to the market config, and initialization is moved from the a/v/sToken `Initialize` event to the RewardsController `EmissionManagerUpdated` and `AssetConfigUpdated` events.

Also changed `Rewards` and `UserRewards` entities from plural to singular to make batch querying possible.