### PR TITLE
feat: add helpful fields for transaction queries

### DIFF
--- a/schemas/v2.schema.graphql
+++ b/schemas/v2.schema.graphql
@@ -212,7 +212,7 @@ enum Action {
 
 interface UserTransaction {
   id: ID!
-  txHash: String!
+  txHash: Bytes!
   action: Action!
   pool: Pool!
   user: User!
@@ -224,6 +224,8 @@ type Deposit implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   caller: User!
@@ -241,6 +243,8 @@ type RedeemUnderlying implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   to: User!
@@ -256,6 +260,8 @@ type Borrow implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   caller: User!
@@ -276,6 +282,8 @@ type Swap implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -292,6 +300,8 @@ type UsageAsCollateral implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -306,6 +316,8 @@ type RebalanceStableBorrowRate implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -321,6 +333,8 @@ type Repay implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   repayer: User!
@@ -352,6 +366,8 @@ type LiquidationCall implements UserTransaction @entity {
   tx hash
   """ # TODO: replace with blockNumber/timestamp + blockPosition
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   collateralReserve: Reserve!

--- a/schemas/v2.schema.graphql
+++ b/schemas/v2.schema.graphql
@@ -234,7 +234,7 @@ type Deposit implements UserTransaction @entity {
   amount: BigInt!
   referrer: Referrer
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 # TODO: check nomenclature for new v2
@@ -252,7 +252,7 @@ type RedeemUnderlying implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type Borrow implements UserTransaction @entity {
@@ -274,7 +274,7 @@ type Borrow implements UserTransaction @entity {
   timestamp: Int!
   stableTokenDebt: BigInt!
   variableTokenDebt: BigInt!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type Swap implements UserTransaction @entity {
@@ -342,7 +342,7 @@ type Repay implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type FlashLoan @entity {
@@ -358,7 +358,7 @@ type FlashLoan @entity {
   #protocolFee: BigInt!
   initiator: User!
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type LiquidationCall implements UserTransaction @entity {
@@ -378,8 +378,8 @@ type LiquidationCall implements UserTransaction @entity {
   principalAmount: BigInt!
   liquidator: Bytes!
   timestamp: Int!
-  collateralAssetPriceUSD: BigInt!
-  borrowAssetPriceUSD: BigInt!
+  collateralAssetPriceUSD: BigDecimal!
+  borrowAssetPriceUSD: BigDecimal!
 }
 
 type ReserveConfigurationHistoryItem @entity {

--- a/schemas/v2.schema.graphql
+++ b/schemas/v2.schema.graphql
@@ -55,7 +55,6 @@ type Pool @entity {
   repayHistory: [Repay!]! @derivedFrom(field: "pool")
   flashLoanHistory: [FlashLoan!]! @derivedFrom(field: "pool")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "pool")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]! @derivedFrom(field: "pool")
 
   active: Boolean!
   paused: Boolean!
@@ -200,8 +199,21 @@ type Referrer @entity {
   borrows: [Borrow!]! @derivedFrom(field: "referrer")
 }
 
+enum Action {
+  Deposit
+  RedeemUnderlying
+  Repay
+  Borrow
+  Swap
+  UsageAsCollateral
+  RebalanceStableBorrowRate
+  LiquidationCall
+}
+
 interface UserTransaction {
   id: ID!
+  txHash: String!
+  action: Action!
   pool: Pool!
   user: User!
   timestamp: Int!
@@ -220,6 +232,7 @@ type Deposit implements UserTransaction @entity {
   amount: BigInt!
   referrer: Referrer
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 # TODO: check nomenclature for new v2
@@ -235,6 +248,7 @@ type RedeemUnderlying implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 type Borrow implements UserTransaction @entity {
@@ -254,6 +268,7 @@ type Borrow implements UserTransaction @entity {
   timestamp: Int!
   stableTokenDebt: BigInt!
   variableTokenDebt: BigInt!
+  assetPriceUSD: BigInt!
 }
 
 type Swap implements UserTransaction @entity {
@@ -313,6 +328,7 @@ type Repay implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 type FlashLoan @entity {
@@ -328,6 +344,7 @@ type FlashLoan @entity {
   #protocolFee: BigInt!
   initiator: User!
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 type LiquidationCall implements UserTransaction @entity {
@@ -345,22 +362,8 @@ type LiquidationCall implements UserTransaction @entity {
   principalAmount: BigInt!
   liquidator: Bytes!
   timestamp: Int!
-}
-
-type OriginationFeeLiquidation implements UserTransaction @entity {
-  """
-  tx hash
-  """ # TODO: replace with blockNumber/timestamp + blockPosition
-  id: ID!
-  pool: Pool!
-  user: User!
-  collateralReserve: Reserve!
-  collateralUserReserve: UserReserve!
-  principalReserve: Reserve!
-  principalUserReserve: UserReserve!
-  feeLiquidated: BigInt!
-  liquidatedCollateralForFee: BigInt!
-  timestamp: Int!
+  collateralAssetPriceUSD: BigInt!
+  borrowAssetPriceUSD: BigInt!
 }
 
 type ReserveConfigurationHistoryItem @entity {
@@ -549,8 +552,6 @@ type Reserve @entity {
   repayHistory: [Repay!]! @derivedFrom(field: "reserve")
   flashLoanHistory: [FlashLoan!]! @derivedFrom(field: "reserve")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "collateralReserve")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]!
-    @derivedFrom(field: "collateralReserve")
   paramsHistory: [ReserveParamsHistoryItem!]! @derivedFrom(field: "reserve")
   configurationHistory: [ReserveConfigurationHistoryItem!]! @derivedFrom(field: "reserve")
   deposits: [Deposit!]! @derivedFrom(field: "reserve")
@@ -691,8 +692,6 @@ type UserReserve @entity {
   rebalanceStableBorrowRateHistory: [RebalanceStableBorrowRate!]! @derivedFrom(field: "userReserve")
   repayHistory: [Repay!]! @derivedFrom(field: "userReserve")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "collateralUserReserve")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]!
-    @derivedFrom(field: "collateralUserReserve")
 }
 
 type User @entity {
@@ -716,7 +715,6 @@ type User @entity {
   rebalanceStableBorrowRateHistory: [RebalanceStableBorrowRate!]! @derivedFrom(field: "user")
   repayHistory: [Repay!]! @derivedFrom(field: "user")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "user")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]! @derivedFrom(field: "user")
   incentivizedActions: [IncentivizedAction!]! @derivedFrom(field: "user")
   claimIncentives: [ClaimIncentiveCall!]! @derivedFrom(field: "user")
 }

--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -142,7 +142,7 @@ enum Action {
 
 interface UserTransaction {
   id: ID!
-  txHash: String!
+  txHash: Bytes!
   action: Action!
   pool: Pool!
   user: User!
@@ -154,6 +154,8 @@ type Supply implements UserTransaction @entity {
   tx hash
   """
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   caller: User!
@@ -170,6 +172,8 @@ type RedeemUnderlying implements UserTransaction @entity {
   tx hash
   """
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   to: User!
@@ -185,6 +189,8 @@ type Borrow implements UserTransaction @entity {
   tx hash
   """
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   caller: User!
@@ -205,6 +211,8 @@ type SwapBorrowRate implements UserTransaction @entity {
   tx hash
   """
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -221,6 +229,8 @@ type UsageAsCollateral implements UserTransaction @entity {
   tx hash
   """ #
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -235,6 +245,8 @@ type RebalanceStableBorrowRate implements UserTransaction @entity {
   tx hash
   """ #
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   reserve: Reserve!
@@ -250,6 +262,8 @@ type Repay implements UserTransaction @entity {
   tx hash
   """
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   repayer: User!
@@ -294,6 +308,8 @@ type LiquidationCall implements UserTransaction @entity {
   tx hash
   """ #
   id: ID!
+  txHash: Bytes!
+  action: Action!
   pool: Pool!
   user: User!
   collateralReserve: Reserve!

--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -164,7 +164,7 @@ type Supply implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type RedeemUnderlying implements UserTransaction @entity {
@@ -181,7 +181,7 @@ type RedeemUnderlying implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type Borrow implements UserTransaction @entity {
@@ -203,7 +203,7 @@ type Borrow implements UserTransaction @entity {
   timestamp: Int!
   stableTokenDebt: BigInt!
   variableTokenDebt: BigInt!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type SwapBorrowRate implements UserTransaction @entity {
@@ -272,7 +272,7 @@ type Repay implements UserTransaction @entity {
   amount: BigInt!
   timestamp: Int!
   useATokens: Boolean!
-  assetPriceUSD: BigInt!
+  assetPriceUSD: BigDecimal!
 }
 
 type IsolationModeTotalDebtUpdated @entity {
@@ -320,8 +320,8 @@ type LiquidationCall implements UserTransaction @entity {
   principalAmount: BigInt!
   liquidator: Bytes!
   timestamp: Int!
-  collateralAssetPriceUSD: BigInt!
-  borrowAssetPriceUSD: BigInt!
+  collateralAssetPriceUSD: BigDecimal!
+  borrowAssetPriceUSD: BigDecimal!
 }
 
 type MintUnbacked @entity {

--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -42,8 +42,6 @@ type Pool @entity {
   repayHistory: [Repay!]! @derivedFrom(field: "pool")
   flashLoanHistory: [FlashLoan!]! @derivedFrom(field: "pool")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "pool")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]! @derivedFrom(field: "pool")
-
   active: Boolean!
   paused: Boolean!
 }
@@ -131,8 +129,21 @@ type Referrer @entity {
   borrows: [Borrow!]! @derivedFrom(field: "referrer")
 }
 
+enum Action {
+  Supply
+  RedeemUnderlying
+  Repay
+  Borrow
+  SwapBorrowRate
+  UsageAsCollateral
+  RebalanceStableBorrowRate
+  LiquidationCall
+}
+
 interface UserTransaction {
   id: ID!
+  txHash: String!
+  action: Action!
   pool: Pool!
   user: User!
   timestamp: Int!
@@ -151,6 +162,7 @@ type Supply implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 type RedeemUnderlying implements UserTransaction @entity {
@@ -165,6 +177,7 @@ type RedeemUnderlying implements UserTransaction @entity {
   userReserve: UserReserve!
   amount: BigInt!
   timestamp: Int!
+  assetPriceUSD: BigInt!
 }
 
 type Borrow implements UserTransaction @entity {
@@ -184,6 +197,7 @@ type Borrow implements UserTransaction @entity {
   timestamp: Int!
   stableTokenDebt: BigInt!
   variableTokenDebt: BigInt!
+  assetPriceUSD: BigInt!
 }
 
 type SwapBorrowRate implements UserTransaction @entity {
@@ -244,6 +258,7 @@ type Repay implements UserTransaction @entity {
   amount: BigInt!
   timestamp: Int!
   useATokens: Boolean!
+  assetPriceUSD: BigInt!
 }
 
 type IsolationModeTotalDebtUpdated @entity {
@@ -289,22 +304,8 @@ type LiquidationCall implements UserTransaction @entity {
   principalAmount: BigInt!
   liquidator: Bytes!
   timestamp: Int!
-}
-
-type OriginationFeeLiquidation implements UserTransaction @entity {
-  """
-  tx hash
-  """ #
-  id: ID!
-  pool: Pool!
-  user: User!
-  collateralReserve: Reserve!
-  collateralUserReserve: UserReserve!
-  principalReserve: Reserve!
-  principalUserReserve: UserReserve!
-  feeLiquidated: BigInt!
-  liquidatedCollateralForFee: BigInt!
-  timestamp: Int!
+  collateralAssetPriceUSD: BigInt!
+  borrowAssetPriceUSD: BigInt!
 }
 
 type MintUnbacked @entity {
@@ -606,8 +607,6 @@ type Reserve @entity {
   repayHistory: [Repay!]! @derivedFrom(field: "reserve")
   flashLoanHistory: [FlashLoan!]! @derivedFrom(field: "reserve")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "collateralReserve")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]!
-    @derivedFrom(field: "collateralReserve")
   paramsHistory: [ReserveParamsHistoryItem!]! @derivedFrom(field: "reserve")
   configurationHistory: [ReserveConfigurationHistoryItem!]! @derivedFrom(field: "reserve")
   supplies: [Supply!]! @derivedFrom(field: "reserve")
@@ -729,8 +728,6 @@ type UserReserve @entity {
   rebalanceStableBorrowRateHistory: [RebalanceStableBorrowRate!]! @derivedFrom(field: "userReserve")
   repayHistory: [Repay!]! @derivedFrom(field: "userReserve")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "collateralUserReserve")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]!
-    @derivedFrom(field: "collateralUserReserve")
 }
 
 type User @entity {
@@ -761,7 +758,6 @@ type User @entity {
   rebalanceStableBorrowRateHistory: [RebalanceStableBorrowRate!]! @derivedFrom(field: "user")
   repayHistory: [Repay!]! @derivedFrom(field: "user")
   liquidationCallHistory: [LiquidationCall!]! @derivedFrom(field: "user")
-  originationFeeLiquidationHistory: [OriginationFeeLiquidation!]! @derivedFrom(field: "user")
   rewardedActions: [RewardedAction!]! @derivedFrom(field: "user")
   claimRewards: [ClaimRewardsCall!]! @derivedFrom(field: "user")
 }

--- a/src/helpers/initializers.ts
+++ b/src/helpers/initializers.ts
@@ -228,11 +228,6 @@ export function getOrInitReserve(underlyingAsset: Bytes, event: ethereum.Event):
     reserve.lifetimeLiquidated = zeroBI();
     reserve.lifetimeFlashLoans = zeroBI();
     reserve.lifetimeFlashLoanPremium = zeroBI();
-    reserve.lifetimeFlashLoanLPPremium = zeroBI();
-    reserve.lifetimeFlashLoanProtocolPremium = zeroBI();
-
-    reserve.lifetimePortalLPFee = zeroBI();
-    reserve.lifetimePortalProtocolFee = zeroBI();
 
     reserve.stableDebtLastUpdateTimestamp = 0;
     reserve.lastUpdateTimestamp = 0;
@@ -345,10 +340,6 @@ export function getOrInitReserveParamsHistoryItem(
     reserveParamsHistoryItem.lifetimeLiquidated = zeroBI();
     reserveParamsHistoryItem.lifetimeFlashLoans = zeroBI();
     reserveParamsHistoryItem.lifetimeFlashLoanPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimeFlashLoanLPPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimeFlashLoanProtocolPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimePortalLPFee = zeroBI();
-    reserveParamsHistoryItem.lifetimePortalProtocolFee = zeroBI();
     reserveParamsHistoryItem.lifetimeReserveFactorAccrued = zeroBI();
     reserveParamsHistoryItem.lifetimeDepositorsInterestEarned = zeroBI();
     // reserveParamsHistoryItem.lifetimeStableDebFeeCollected = zeroBI();

--- a/src/mapping/lending-pool/lending-pool.ts
+++ b/src/mapping/lending-pool/lending-pool.ts
@@ -42,7 +42,7 @@ import {
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
-import { ETH_PRECISION } from '../../utils/constants';
+import { ETH_PRECISION, USD_PRECISION } from '../../utils/constants';
 
 export function handleDeposit(event: Deposit): void {
   let caller = event.params.user;
@@ -70,6 +70,8 @@ export function handleDeposit(event: Deposit): void {
     deposit.assetPriceUSD = priceOracleAsset.priceInEth
       .divDecimal(ETH_PRECISION)
       .times(ethPriceUSD);
+  } else {
+    deposit.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   }
   if (event.params.referral) {
     let referrer = getOrInitReferrer(event.params.referral);
@@ -103,6 +105,8 @@ export function handleWithdraw(event: Withdraw): void {
     redeemUnderlying.assetPriceUSD = priceOracleAsset.priceInEth
       .divDecimal(ETH_PRECISION)
       .times(ethPriceUSD);
+  } else {
+    redeemUnderlying.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   }
   redeemUnderlying.save();
 }
@@ -138,6 +142,8 @@ export function handleBorrow(event: Borrow): void {
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
     borrow.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(ETH_PRECISION).times(ethPriceUSD);
+  } else {
+    borrow.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   }
   borrow.save();
 }
@@ -226,6 +232,8 @@ export function handleRepay(event: Repay): void {
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
     repay.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(ETH_PRECISION).times(ethPriceUSD);
+  } else {
+    repay.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   }
   repay.save();
 }
@@ -266,18 +274,25 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   liquidationCall.liquidator = event.params.liquidator;
   liquidationCall.timestamp = event.block.timestamp.toI32();
   let usdPriceEth = PriceOracle.load('1');
+  let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
+  let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
   if (usdPriceEth) {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
-    let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
-    let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
     liquidationCall.collateralAssetPriceUSD = collateralPriceOracleAsset.priceInEth
       .divDecimal(ETH_PRECISION)
       .times(ethPriceUSD);
     liquidationCall.borrowAssetPriceUSD = borrowPriceOracleAsset.priceInEth
       .divDecimal(ETH_PRECISION)
       .times(ethPriceUSD);
+  } else {
+    liquidationCall.collateralAssetPriceUSD = collateralPriceOracleAsset.priceInEth.divDecimal(
+      USD_PRECISION
+    );
+    liquidationCall.borrowAssetPriceUSD = borrowPriceOracleAsset.priceInEth.divDecimal(
+      USD_PRECISION
+    );
   }
   liquidationCall.save();
 }

--- a/src/mapping/lending-pool/lending-pool.ts
+++ b/src/mapping/lending-pool/lending-pool.ts
@@ -39,7 +39,6 @@ import {
   Repay as RepayAction,
   Swap as SwapAction,
   UsageAsCollateral as UsageAsCollateralAction,
-  Action,
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
@@ -53,7 +52,7 @@ export function handleDeposit(event: Deposit): void {
 
   let deposit = new DepositAction(getHistoryEntityId(event));
   deposit.txHash = event.transaction.hash;
-  deposit.action = Action.Deposit;
+  deposit.action = 'Deposit';
   deposit.pool = poolReserve.pool;
   deposit.user = userReserve.user;
   deposit.caller = getOrInitUser(caller).id;
@@ -62,9 +61,11 @@ export function handleDeposit(event: Deposit): void {
   deposit.amount = depositedAmount;
   deposit.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
-  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
-  deposit.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  let usdPriceEth = PriceOracle.load('1');
+  if (usdPriceEth) {
+    let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth.usdPriceEth);
+    deposit.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  }
   if (event.params.referral) {
     let referrer = getOrInitReferrer(event.params.referral);
     deposit.referrer = referrer.id;
@@ -80,7 +81,7 @@ export function handleWithdraw(event: Withdraw): void {
 
   let redeemUnderlying = new RedeemUnderlyingAction(getHistoryEntityId(event));
   redeemUnderlying.txHash = event.transaction.hash;
-  redeemUnderlying.action = Action.RedeemUnderlying;
+  redeemUnderlying.action = 'RedeemUnderlying';
   redeemUnderlying.pool = poolReserve.pool;
   redeemUnderlying.user = userReserve.user;
   redeemUnderlying.to = toUser.id;
@@ -89,9 +90,11 @@ export function handleWithdraw(event: Withdraw): void {
   redeemUnderlying.amount = redeemedAmount;
   redeemUnderlying.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
-  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
-  redeemUnderlying.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  let usdPriceEth = PriceOracle.load('1');
+  if (usdPriceEth) {
+    let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth.usdPriceEth);
+    redeemUnderlying.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  }
   redeemUnderlying.save();
 }
 
@@ -103,7 +106,7 @@ export function handleBorrow(event: Borrow): void {
 
   let borrow = new BorrowAction(getHistoryEntityId(event));
   borrow.txHash = event.transaction.hash;
-  boeeow.action = Action.Borrow;
+  borrow.action = 'Borrow';
   borrow.pool = poolReserve.pool;
   borrow.user = userReserve.user;
   borrow.caller = getOrInitUser(caller).id;
@@ -120,9 +123,11 @@ export function handleBorrow(event: Borrow): void {
     borrow.referrer = referrer.id;
   }
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
-  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
-  borrow.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  let usdPriceEth = PriceOracle.load('1');
+  if (usdPriceEth) {
+    let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth.usdPriceEth);
+    borrow.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  }
   borrow.save();
 }
 
@@ -151,7 +156,7 @@ export function handleSwap(event: Swap): void {
 
   let swapHistoryItem = new SwapAction(getHistoryEntityId(event));
   swapHistoryItem.txHash = event.transaction.hash;
-  swapHistoryItem.action = Action.Swap;
+  swapHistoryItem.action = 'Swap';
   swapHistoryItem.pool = poolReserve.pool;
   swapHistoryItem.borrowRateModeFrom = getBorrowRateMode(event.params.rateMode);
   if (swapHistoryItem.borrowRateModeFrom === BORROW_MODE_STABLE) {
@@ -175,7 +180,7 @@ export function handleRebalanceStableBorrowRate(event: RebalanceStableBorrowRate
 
   let rebalance = new RebalanceStableBorrowRateAction(getHistoryEntityId(event));
   rebalance.txHash = event.transaction.hash;
-  rebalance.action = Action.RebalanceStableBorrowRate;
+  rebalance.action = 'RebalanceStableBorrowRate';
   rebalance.userReserve = userReserve.id;
   rebalance.borrowRateFrom = userReserve.oldStableBorrowRate;
   rebalance.borrowRateTo = userReserve.stableBorrowRate;
@@ -195,7 +200,7 @@ export function handleRepay(event: Repay): void {
 
   let repay = new RepayAction(getHistoryEntityId(event));
   repay.txHash = event.transaction.hash;
-  repay.action = Action.Repay;
+  repay.action = 'Repay';
   repay.pool = poolReserve.pool;
   repay.user = userReserve.user;
   repay.repayer = repayer.id;
@@ -204,9 +209,11 @@ export function handleRepay(event: Repay): void {
   repay.amount = event.params.amount;
   repay.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
-  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
-  repay.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  let usdPriceEth = PriceOracle.load('1');
+  if (usdPriceEth) {
+    let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth.usdPriceEth);
+    repay.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
+  }
   repay.save();
 }
 
@@ -234,7 +241,7 @@ export function handleLiquidationCall(event: LiquidationCall): void {
 
   let liquidationCall = new LiquidationCallAction(getHistoryEntityId(event));
   liquidationCall.txHash = event.transaction.hash;
-  liquidationCall.action = Action.LiquidationCall;
+  liquidationCall.action = 'LiquidationCall';
   liquidationCall.pool = collateralPoolReserve.pool;
   liquidationCall.user = user.id;
   liquidationCall.collateralReserve = collateralPoolReserve.id;
@@ -245,14 +252,16 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   liquidationCall.principalAmount = event.params.debtToCover;
   liquidationCall.liquidator = event.params.liquidator;
   liquidationCall.timestamp = event.block.timestamp.toI32();
-  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
-  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
-  let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
-  liquidationCall.collateralAssetPriceUSD = ethPriceUsd.times(
-    collateralPriceOracleAsset.priceInEth
-  );
-  let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
-  liquidationCall.borrowAssetPriceUSD = ethPriceUsd.times(borrowPriceOracleAsset.priceInEth);
+  let usdPriceEth = PriceOracle.load('1');
+  if (usdPriceEth) {
+    let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth.usdPriceEth);
+    let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
+    liquidationCall.collateralAssetPriceUSD = ethPriceUsd.times(
+      collateralPriceOracleAsset.priceInEth
+    );
+    let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
+    liquidationCall.borrowAssetPriceUSD = ethPriceUsd.times(borrowPriceOracleAsset.priceInEth);
+  }
   liquidationCall.save();
 }
 
@@ -288,7 +297,7 @@ export function handleReserveUsedAsCollateralEnabled(event: ReserveUsedAsCollate
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
   usageAsCollateral.txHash = event.transaction.hash;
-  usageAsCollateral.action = Action.UsageAsCollateral;
+  usageAsCollateral.action = 'UsageAsCollateral';
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = true;
@@ -312,7 +321,7 @@ export function handleReserveUsedAsCollateralDisabled(
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
   usageAsCollateral.txHash = event.transaction.hash;
-  usageAsCollateral.action = Action.UsageAsCollateral;
+  usageAsCollateral.action = 'UsageAsCollateral';
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = false;

--- a/src/mapping/lending-pool/lending-pool.ts
+++ b/src/mapping/lending-pool/lending-pool.ts
@@ -63,7 +63,7 @@ export function handleDeposit(event: Deposit): void {
   deposit.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
   let usdPriceEth = PriceOracle.load('1');
-  if (usdPriceEth) {
+  if (usdPriceEth && usdPriceEth.usdPriceEth.toString() != '0') {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
@@ -98,7 +98,7 @@ export function handleWithdraw(event: Withdraw): void {
   redeemUnderlying.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
   let usdPriceEth = PriceOracle.load('1');
-  if (usdPriceEth) {
+  if (usdPriceEth && usdPriceEth.usdPriceEth.toString() != '0') {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
@@ -137,7 +137,7 @@ export function handleBorrow(event: Borrow): void {
   }
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
   let usdPriceEth = PriceOracle.load('1');
-  if (usdPriceEth) {
+  if (usdPriceEth && usdPriceEth.usdPriceEth.toString() != '0') {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
@@ -227,7 +227,7 @@ export function handleRepay(event: Repay): void {
   repay.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
   let usdPriceEth = PriceOracle.load('1');
-  if (usdPriceEth) {
+  if (usdPriceEth && usdPriceEth.usdPriceEth.toString() != '0') {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );
@@ -276,7 +276,7 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   let usdPriceEth = PriceOracle.load('1');
   let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
   let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
-  if (usdPriceEth) {
+  if (usdPriceEth && usdPriceEth.usdPriceEth.toString() != '0') {
     const ethPriceUSD = BigDecimal.fromString('1').div(
       usdPriceEth.usdPriceEth.divDecimal(ETH_PRECISION)
     );

--- a/src/mapping/lending-pool/lending-pool.ts
+++ b/src/mapping/lending-pool/lending-pool.ts
@@ -25,6 +25,7 @@ import {
   getOrInitUser,
   getOrInitUserReserve,
   getPoolByContract,
+  getPriceOracleAsset,
 } from '../../helpers/initializers';
 import {
   Borrow as BorrowAction,
@@ -32,11 +33,13 @@ import {
   FlashLoan as FlashLoanAction,
   LiquidationCall as LiquidationCallAction,
   Pool,
+  PriceOracle,
   RebalanceStableBorrowRate as RebalanceStableBorrowRateAction,
   RedeemUnderlying as RedeemUnderlyingAction,
   Repay as RepayAction,
   Swap as SwapAction,
   UsageAsCollateral as UsageAsCollateralAction,
+  Action,
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
@@ -49,6 +52,8 @@ export function handleDeposit(event: Deposit): void {
   let depositedAmount = event.params.amount;
 
   let deposit = new DepositAction(getHistoryEntityId(event));
+  deposit.txHash = event.transaction.hash;
+  deposit.action = Action.Deposit;
   deposit.pool = poolReserve.pool;
   deposit.user = userReserve.user;
   deposit.caller = getOrInitUser(caller).id;
@@ -56,6 +61,10 @@ export function handleDeposit(event: Deposit): void {
   deposit.reserve = poolReserve.id;
   deposit.amount = depositedAmount;
   deposit.timestamp = event.block.timestamp.toI32();
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
+  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
+  deposit.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
   if (event.params.referral) {
     let referrer = getOrInitReferrer(event.params.referral);
     deposit.referrer = referrer.id;
@@ -70,6 +79,8 @@ export function handleWithdraw(event: Withdraw): void {
   let redeemedAmount = event.params.amount;
 
   let redeemUnderlying = new RedeemUnderlyingAction(getHistoryEntityId(event));
+  redeemUnderlying.txHash = event.transaction.hash;
+  redeemUnderlying.action = Action.RedeemUnderlying;
   redeemUnderlying.pool = poolReserve.pool;
   redeemUnderlying.user = userReserve.user;
   redeemUnderlying.to = toUser.id;
@@ -77,6 +88,10 @@ export function handleWithdraw(event: Withdraw): void {
   redeemUnderlying.reserve = poolReserve.id;
   redeemUnderlying.amount = redeemedAmount;
   redeemUnderlying.timestamp = event.block.timestamp.toI32();
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
+  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
+  redeemUnderlying.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
   redeemUnderlying.save();
 }
 
@@ -87,6 +102,8 @@ export function handleBorrow(event: Borrow): void {
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let borrow = new BorrowAction(getHistoryEntityId(event));
+  borrow.txHash = event.transaction.hash;
+  boeeow.action = Action.Borrow;
   borrow.pool = poolReserve.pool;
   borrow.user = userReserve.user;
   borrow.caller = getOrInitUser(caller).id;
@@ -102,6 +119,10 @@ export function handleBorrow(event: Borrow): void {
     let referrer = getOrInitReferrer(event.params.referral);
     borrow.referrer = referrer.id;
   }
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
+  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
+  borrow.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
   borrow.save();
 }
 
@@ -129,6 +150,8 @@ export function handleSwap(event: Swap): void {
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let swapHistoryItem = new SwapAction(getHistoryEntityId(event));
+  swapHistoryItem.txHash = event.transaction.hash;
+  swapHistoryItem.action = Action.Swap;
   swapHistoryItem.pool = poolReserve.pool;
   swapHistoryItem.borrowRateModeFrom = getBorrowRateMode(event.params.rateMode);
   if (swapHistoryItem.borrowRateModeFrom === BORROW_MODE_STABLE) {
@@ -151,7 +174,8 @@ export function handleRebalanceStableBorrowRate(event: RebalanceStableBorrowRate
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let rebalance = new RebalanceStableBorrowRateAction(getHistoryEntityId(event));
-
+  rebalance.txHash = event.transaction.hash;
+  rebalance.action = Action.RebalanceStableBorrowRate;
   rebalance.userReserve = userReserve.id;
   rebalance.borrowRateFrom = userReserve.oldStableBorrowRate;
   rebalance.borrowRateTo = userReserve.stableBorrowRate;
@@ -170,6 +194,8 @@ export function handleRepay(event: Repay): void {
   poolReserve.save();
 
   let repay = new RepayAction(getHistoryEntityId(event));
+  repay.txHash = event.transaction.hash;
+  repay.action = Action.Repay;
   repay.pool = poolReserve.pool;
   repay.user = userReserve.user;
   repay.repayer = repayer.id;
@@ -177,6 +203,10 @@ export function handleRepay(event: Repay): void {
   repay.reserve = poolReserve.id;
   repay.amount = event.params.amount;
   repay.timestamp = event.block.timestamp.toI32();
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
+  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
+  repay.assetPriceUSD = ethPriceUsd.times(priceOracleAsset.priceInEth);
   repay.save();
 }
 
@@ -203,6 +233,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   principalPoolReserve.save();
 
   let liquidationCall = new LiquidationCallAction(getHistoryEntityId(event));
+  liquidationCall.txHash = event.transaction.hash;
+  liquidationCall.action = Action.LiquidationCall;
   liquidationCall.pool = collateralPoolReserve.pool;
   liquidationCall.user = user.id;
   liquidationCall.collateralReserve = collateralPoolReserve.id;
@@ -213,6 +245,14 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   liquidationCall.principalAmount = event.params.debtToCover;
   liquidationCall.liquidator = event.params.liquidator;
   liquidationCall.timestamp = event.block.timestamp.toI32();
+  let usdPriceEth = PriceOracle.load('1').usdPriceEth;
+  let ethPriceUsd = BigInt.fromString('1').div(usdPriceEth);
+  let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
+  liquidationCall.collateralAssetPriceUSD = ethPriceUsd.times(
+    collateralPriceOracleAsset.priceInEth
+  );
+  let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
+  liquidationCall.borrowAssetPriceUSD = ethPriceUsd.times(borrowPriceOracleAsset.priceInEth);
   liquidationCall.save();
 }
 
@@ -247,6 +287,8 @@ export function handleReserveUsedAsCollateralEnabled(event: ReserveUsedAsCollate
   let timestamp = event.block.timestamp.toI32();
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
+  usageAsCollateral.txHash = event.transaction.hash;
+  usageAsCollateral.action = Action.UsageAsCollateral;
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = true;
@@ -269,6 +311,8 @@ export function handleReserveUsedAsCollateralDisabled(
   let timestamp = event.block.timestamp.toI32();
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
+  usageAsCollateral.txHash = event.transaction.hash;
+  usageAsCollateral.action = Action.UsageAsCollateral;
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = false;

--- a/src/mapping/lending-pool/v3.ts
+++ b/src/mapping/lending-pool/v3.ts
@@ -41,7 +41,6 @@ import {
   MintedToTreasury as MintedToTreasuryAction,
   IsolationModeTotalDebtUpdated as IsolationModeTotalDebtUpdatedAction,
   Pool,
-  Action,
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
@@ -61,7 +60,7 @@ export function handleSupply(event: Supply): void {
 
   let supply = new SupplyAction(id);
   supply.txHash = event.transaction.hash;
-  supply.action = Action.Supply;
+  supply.action = 'Supply';
   supply.pool = poolReserve.pool;
   supply.user = userReserve.user;
   supply.caller = getOrInitUser(caller).id;
@@ -89,7 +88,7 @@ export function handleWithdraw(event: Withdraw): void {
 
   let redeemUnderlying = new RedeemUnderlyingAction(getHistoryEntityId(event));
   redeemUnderlying.txHash = event.transaction.hash;
-  redeemUnderlying.action = Action.RedeemUnderlying;
+  redeemUnderlying.action = 'RedeemUnderlying';
   redeemUnderlying.pool = poolReserve.pool;
   redeemUnderlying.user = userReserve.user;
   redeemUnderlying.to = toUser.id;
@@ -110,7 +109,7 @@ export function handleBorrow(event: Borrow): void {
 
   let borrow = new BorrowAction(getHistoryEntityId(event));
   borrow.txHash = event.transaction.hash;
-  borrow.action = Action.Borrow;
+  borrow.action = 'Borrow';
   borrow.pool = poolReserve.pool;
   borrow.user = userReserve.user;
   borrow.caller = getOrInitUser(caller).id;
@@ -137,7 +136,7 @@ export function handleSwapBorrowRateMode(event: SwapBorrowRateMode): void {
 
   let swapHistoryItem = new SwapBorrowRateAction(getHistoryEntityId(event));
   swapHistoryItem.txHash = event.transaction.hash;
-  swapHistoryItem.action = Action.SwapBorrowRate;
+  swapHistoryItem.action = 'SwapBorrowRate';
   swapHistoryItem.pool = poolReserve.pool;
   swapHistoryItem.borrowRateModeFrom = event.params.interestRateMode;
   if (swapHistoryItem.borrowRateModeFrom === 1) {
@@ -161,7 +160,7 @@ export function handleRebalanceStableBorrowRate(event: RebalanceStableBorrowRate
 
   let rebalance = new RebalanceStableBorrowRateAction(getHistoryEntityId(event));
   rebalance.txHash = event.transaction.hash;
-  rebalance.action = Action.RebalanceStableBorrowRate;
+  rebalance.action = 'RebalanceStableBorrowRate';
   rebalance.userReserve = userReserve.id;
   rebalance.borrowRateFrom = userReserve.oldStableBorrowRate;
   rebalance.borrowRateTo = userReserve.stableBorrowRate;
@@ -182,7 +181,7 @@ export function handleRepay(event: Repay): void {
 
   let repay = new RepayAction(getHistoryEntityId(event));
   repay.txHash = event.transaction.hash;
-  repay.action = Action.Repay;
+  repay.action = 'Repay';
   repay.pool = poolReserve.pool;
   repay.user = userReserve.user;
   repay.repayer = getOrInitUser(repayer).id;
@@ -220,7 +219,7 @@ export function handleLiquidationCall(event: LiquidationCall): void {
 
   let liquidationCall = new LiquidationCallAction(getHistoryEntityId(event));
   liquidationCall.txHash = event.transaction.hash;
-  liquidationCall.action = Action.LiquidationCall;
+  liquidationCall.action = 'LiquidationCall';
   liquidationCall.pool = collateralPoolReserve.pool;
   liquidationCall.user = user.id;
   liquidationCall.collateralReserve = collateralPoolReserve.id;
@@ -287,7 +286,7 @@ export function handleReserveUsedAsCollateralEnabled(event: ReserveUsedAsCollate
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
   usageAsCollateral.txHash = event.transaction.hash;
-  usageAsCollateral.action = Action.UsageAsCollateral;
+  usageAsCollateral.action = 'UsageAsCollateral';
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = true;
@@ -311,7 +310,7 @@ export function handleReserveUsedAsCollateralDisabled(
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
   usageAsCollateral.txHash = event.transaction.hash;
-  usageAsCollateral.action = Action.UsageAsCollateral;
+  usageAsCollateral.action = 'UsageAsCollateral';
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = false;

--- a/src/mapping/lending-pool/v3.ts
+++ b/src/mapping/lending-pool/v3.ts
@@ -23,6 +23,7 @@ import {
   getOrInitUser,
   getOrInitUserReserve,
   getPoolByContract,
+  getPriceOracleAsset,
 } from '../../helpers/v3/initializers';
 import {
   Borrow as BorrowAction,
@@ -40,6 +41,7 @@ import {
   MintedToTreasury as MintedToTreasuryAction,
   IsolationModeTotalDebtUpdated as IsolationModeTotalDebtUpdatedAction,
   Pool,
+  Action,
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
@@ -58,6 +60,8 @@ export function handleSupply(event: Supply): void {
   }
 
   let supply = new SupplyAction(id);
+  supply.txHash = event.transaction.hash;
+  supply.action = Action.Supply;
   supply.pool = poolReserve.pool;
   supply.user = userReserve.user;
   supply.caller = getOrInitUser(caller).id;
@@ -65,6 +69,8 @@ export function handleSupply(event: Supply): void {
   supply.reserve = poolReserve.id;
   supply.amount = amount;
   supply.timestamp = event.block.timestamp.toI32();
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  supply.assetPriceUSD = priceOracleAsset.priceInEth;
   if (event.params.referralCode) {
     let referrer = getOrInitReferrer(event.params.referralCode);
     supply.referrer = referrer.id;
@@ -82,6 +88,8 @@ export function handleWithdraw(event: Withdraw): void {
   // as the event emitted will contain user and to equal to WethGateway address
 
   let redeemUnderlying = new RedeemUnderlyingAction(getHistoryEntityId(event));
+  redeemUnderlying.txHash = event.transaction.hash;
+  redeemUnderlying.action = Action.RedeemUnderlying;
   redeemUnderlying.pool = poolReserve.pool;
   redeemUnderlying.user = userReserve.user;
   redeemUnderlying.to = toUser.id;
@@ -89,6 +97,8 @@ export function handleWithdraw(event: Withdraw): void {
   redeemUnderlying.reserve = poolReserve.id;
   redeemUnderlying.amount = redeemedAmount;
   redeemUnderlying.timestamp = event.block.timestamp.toI32();
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  redeemUnderlying.assetPriceUSD = priceOracleAsset.priceInEth;
   redeemUnderlying.save();
 }
 
@@ -99,6 +109,8 @@ export function handleBorrow(event: Borrow): void {
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let borrow = new BorrowAction(getHistoryEntityId(event));
+  borrow.txHash = event.transaction.hash;
+  borrow.action = Action.Borrow;
   borrow.pool = poolReserve.pool;
   borrow.user = userReserve.user;
   borrow.caller = getOrInitUser(caller).id;
@@ -114,6 +126,8 @@ export function handleBorrow(event: Borrow): void {
     let referrer = getOrInitReferrer(event.params.referralCode);
     borrow.referrer = referrer.id;
   }
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  borrow.assetPriceUSD = priceOracleAsset.priceInEth;
   borrow.save();
 }
 
@@ -122,6 +136,8 @@ export function handleSwapBorrowRateMode(event: SwapBorrowRateMode): void {
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let swapHistoryItem = new SwapBorrowRateAction(getHistoryEntityId(event));
+  swapHistoryItem.txHash = event.transaction.hash;
+  swapHistoryItem.action = Action.SwapBorrowRate;
   swapHistoryItem.pool = poolReserve.pool;
   swapHistoryItem.borrowRateModeFrom = event.params.interestRateMode;
   if (swapHistoryItem.borrowRateModeFrom === 1) {
@@ -144,7 +160,8 @@ export function handleRebalanceStableBorrowRate(event: RebalanceStableBorrowRate
   let poolReserve = getOrInitReserve(event.params.reserve, event);
 
   let rebalance = new RebalanceStableBorrowRateAction(getHistoryEntityId(event));
-
+  rebalance.txHash = event.transaction.hash;
+  rebalance.action = Action.RebalanceStableBorrowRate;
   rebalance.userReserve = userReserve.id;
   rebalance.borrowRateFrom = userReserve.oldStableBorrowRate;
   rebalance.borrowRateTo = userReserve.stableBorrowRate;
@@ -164,6 +181,8 @@ export function handleRepay(event: Repay): void {
   poolReserve.save();
 
   let repay = new RepayAction(getHistoryEntityId(event));
+  repay.txHash = event.transaction.hash;
+  repay.action = Action.Repay;
   repay.pool = poolReserve.pool;
   repay.user = userReserve.user;
   repay.repayer = getOrInitUser(repayer).id;
@@ -172,6 +191,8 @@ export function handleRepay(event: Repay): void {
   repay.amount = event.params.amount;
   repay.timestamp = event.block.timestamp.toI32();
   repay.useATokens = event.params.useATokens;
+  let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
+  repay.assetPriceUSD = priceOracleAsset.priceInEth;
   repay.save();
 }
 
@@ -198,6 +219,8 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   principalPoolReserve.save();
 
   let liquidationCall = new LiquidationCallAction(getHistoryEntityId(event));
+  liquidationCall.txHash = event.transaction.hash;
+  liquidationCall.action = Action.LiquidationCall;
   liquidationCall.pool = collateralPoolReserve.pool;
   liquidationCall.user = user.id;
   liquidationCall.collateralReserve = collateralPoolReserve.id;
@@ -208,6 +231,10 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   liquidationCall.principalAmount = event.params.debtToCover;
   liquidationCall.liquidator = event.params.liquidator;
   liquidationCall.timestamp = event.block.timestamp.toI32();
+  let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
+  let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
+  liquidationCall.collateralAssetPriceUSD = collateralPriceOracleAsset.priceInEth;
+  liquidationCall.borrowAssetPriceUSD = borrowPriceOracleAsset.priceInEth;
   liquidationCall.save();
 }
 
@@ -259,6 +286,8 @@ export function handleReserveUsedAsCollateralEnabled(event: ReserveUsedAsCollate
   let timestamp = event.block.timestamp.toI32();
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
+  usageAsCollateral.txHash = event.transaction.hash;
+  usageAsCollateral.action = Action.UsageAsCollateral;
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = true;
@@ -281,6 +310,8 @@ export function handleReserveUsedAsCollateralDisabled(
   let timestamp = event.block.timestamp.toI32();
 
   let usageAsCollateral = new UsageAsCollateralAction(getHistoryEntityId(event));
+  usageAsCollateral.txHash = event.transaction.hash;
+  usageAsCollateral.action = Action.UsageAsCollateral;
   usageAsCollateral.pool = poolReserve.pool;
   usageAsCollateral.fromState = userReserve.usageAsCollateralEnabledOnUser;
   usageAsCollateral.toState = false;

--- a/src/mapping/lending-pool/v3.ts
+++ b/src/mapping/lending-pool/v3.ts
@@ -44,6 +44,7 @@ import {
 } from '../../../generated/schema';
 import { getHistoryEntityId } from '../../utils/id-generation';
 import { calculateGrowth } from '../../helpers/math';
+import { USD_PRECISION } from '../../utils/constants';
 
 export function handleSupply(event: Supply): void {
   let caller = event.params.user;
@@ -69,7 +70,7 @@ export function handleSupply(event: Supply): void {
   supply.amount = amount;
   supply.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  supply.assetPriceUSD = priceOracleAsset.priceInEth;
+  supply.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   if (event.params.referralCode) {
     let referrer = getOrInitReferrer(event.params.referralCode);
     supply.referrer = referrer.id;
@@ -97,7 +98,7 @@ export function handleWithdraw(event: Withdraw): void {
   redeemUnderlying.amount = redeemedAmount;
   redeemUnderlying.timestamp = event.block.timestamp.toI32();
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  redeemUnderlying.assetPriceUSD = priceOracleAsset.priceInEth;
+  redeemUnderlying.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   redeemUnderlying.save();
 }
 
@@ -126,7 +127,7 @@ export function handleBorrow(event: Borrow): void {
     borrow.referrer = referrer.id;
   }
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  borrow.assetPriceUSD = priceOracleAsset.priceInEth;
+  borrow.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   borrow.save();
 }
 
@@ -191,7 +192,7 @@ export function handleRepay(event: Repay): void {
   repay.timestamp = event.block.timestamp.toI32();
   repay.useATokens = event.params.useATokens;
   let priceOracleAsset = getPriceOracleAsset(poolReserve.price);
-  repay.assetPriceUSD = priceOracleAsset.priceInEth;
+  repay.assetPriceUSD = priceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   repay.save();
 }
 
@@ -232,8 +233,10 @@ export function handleLiquidationCall(event: LiquidationCall): void {
   liquidationCall.timestamp = event.block.timestamp.toI32();
   let collateralPriceOracleAsset = getPriceOracleAsset(collateralPoolReserve.price);
   let borrowPriceOracleAsset = getPriceOracleAsset(principalPoolReserve.price);
-  liquidationCall.collateralAssetPriceUSD = collateralPriceOracleAsset.priceInEth;
-  liquidationCall.borrowAssetPriceUSD = borrowPriceOracleAsset.priceInEth;
+  liquidationCall.collateralAssetPriceUSD = collateralPriceOracleAsset.priceInEth.divDecimal(
+    USD_PRECISION
+  );
+  liquidationCall.borrowAssetPriceUSD = borrowPriceOracleAsset.priceInEth.divDecimal(USD_PRECISION);
   liquidationCall.save();
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,6 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 export const ETH_PRECISION = BigInt.fromI32(10)
   .pow(18)
   .toBigDecimal();
+export const USD_PRECISION = BigInt.fromI32(10)
+  .pow(8)
+  .toBigDecimal();

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,9 @@
+import { BigInt } from '@graphprotocol/graph-ts';
+
 export const MOCK_ETHEREUM_ADDRESS = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 export const MOCK_USD_ADDRESS = '0x10f7fc1f91ba351f9c629c5947ad69bd03c05b96';
 export const PROPOSAL_STATUS_INITIALIZING = 'Initializing';
 export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const ETH_PRECISION = BigInt.fromI32(10)
+  .pow(18)
+  .toBigDecimal();


### PR DESCRIPTION
For V2 and V3:

- [x] Add txHash to UserTransaction
- [x] Add action to UserTransaction (to specify Supply, Borrow, Repay, etc.)
- [x] Add assetPriceUsd to core actions (Supply, Borrow, Repay, RedeemUnderlying, Flashloan) - V3 + Avalanche USD oracles
- [x] Add assetPriceUsd to core actions (Supply, Borrow, Repay, RedeemUnderlying, Flashloan) - V2 ETH oracles
- [x] Add collateralPriceUsd and borrowPriceUsd to LiquidationCall
- [x] Remove unnecessary OriginationFeeLiquidation entity from schema