### PR TITLE
fix: remove v3 schema at v2's initializer

### DIFF
--- a/src/helpers/initializers.ts
+++ b/src/helpers/initializers.ts
@@ -228,11 +228,6 @@ export function getOrInitReserve(underlyingAsset: Bytes, event: ethereum.Event):
     reserve.lifetimeLiquidated = zeroBI();
     reserve.lifetimeFlashLoans = zeroBI();
     reserve.lifetimeFlashLoanPremium = zeroBI();
-    reserve.lifetimeFlashLoanLPPremium = zeroBI();
-    reserve.lifetimeFlashLoanProtocolPremium = zeroBI();
-
-    reserve.lifetimePortalLPFee = zeroBI();
-    reserve.lifetimePortalProtocolFee = zeroBI();
 
     reserve.stableDebtLastUpdateTimestamp = 0;
     reserve.lastUpdateTimestamp = 0;
@@ -345,10 +340,6 @@ export function getOrInitReserveParamsHistoryItem(
     reserveParamsHistoryItem.lifetimeLiquidated = zeroBI();
     reserveParamsHistoryItem.lifetimeFlashLoans = zeroBI();
     reserveParamsHistoryItem.lifetimeFlashLoanPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimeFlashLoanLPPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimeFlashLoanProtocolPremium = zeroBI();
-    reserveParamsHistoryItem.lifetimePortalLPFee = zeroBI();
-    reserveParamsHistoryItem.lifetimePortalProtocolFee = zeroBI();
     reserveParamsHistoryItem.lifetimeReserveFactorAccrued = zeroBI();
     reserveParamsHistoryItem.lifetimeDepositorsInterestEarned = zeroBI();
     // reserveParamsHistoryItem.lifetimeStableDebFeeCollected = zeroBI();


### PR DESCRIPTION
An incorrect initializer makes v2 unable to deploy.