### PR TITLE
Fix balances for v3

### DIFF
--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -402,7 +402,8 @@ export function handleVariableTokenMint(event: VTokenMint): void {
 }
 
 export function handleStableTokenMint(event: STokenMint): void {
-  let borrowedAmount = event.params.amount;
+  let balanceChangeIncludingInterest = event.params.amount;
+  let borrowedAmount = event.params.amount.minus(event.params.balanceIncrease);
   let sToken = getOrInitSubToken(event.address);
   let from = event.params.user;
   if (from.toHexString() != event.params.onBehalfOf.toHexString()) {
@@ -421,10 +422,9 @@ export function handleStableTokenMint(event: STokenMint): void {
     user.save();
   }
 
-  let calculatedAmount = event.params.amount.plus(event.params.balanceIncrease);
   poolReserve.totalPrincipalStableDebt = event.params.newTotalSupply;
   poolReserve.lifetimePrincipalStableDebt = poolReserve.lifetimePrincipalStableDebt.plus(
-    calculatedAmount
+    balanceChangeIncludingInterest
   );
 
   poolReserve.averageStableRate = event.params.avgStableRate;
@@ -437,7 +437,9 @@ export function handleStableTokenMint(event: STokenMint): void {
 
   saveReserve(poolReserve, event);
 
-  userReserve.principalStableDebt = userReserve.principalStableDebt.plus(calculatedAmount);
+  userReserve.principalStableDebt = userReserve.principalStableDebt.plus(
+    balanceChangeIncludingInterest
+  );
   userReserve.currentStableDebt = userReserve.principalStableDebt;
   userReserve.currentTotalDebt = userReserve.currentStableDebt.plus(
     userReserve.currentVariableDebt

--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -149,8 +149,8 @@ function tokenBurn(
   let userReserve = getOrInitUserReserve(from, aToken.underlyingAssetAddress, event);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
 
-  const balanceChange = value.plus(balanceIncrease);
-  let calculatedAmount = rayDiv(balanceChange, index);
+  const userBalanceChange = value.plus(balanceIncrease);
+  let calculatedAmount = rayDiv(userBalanceChange, index);
 
   userReserve.scaledATokenBalance = userReserve.scaledATokenBalance.minus(calculatedAmount);
   userReserve.currentATokenBalance = rayMul(userReserve.scaledATokenBalance, index);
@@ -158,20 +158,20 @@ function tokenBurn(
   userReserve.liquidityRate = poolReserve.liquidityRate;
 
   // TODO: review liquidity?
-  poolReserve.totalSupplies = poolReserve.totalSupplies.minus(balanceChange);
+  poolReserve.totalSupplies = poolReserve.totalSupplies.minus(userBalanceChange);
   // poolReserve.availableLiquidity = poolReserve.totalDeposits
   //   .minus(poolReserve.totalPrincipalStableDebt)
   //   .minus(poolReserve.totalScaledVariableDebt);
 
-  poolReserve.availableLiquidity = poolReserve.availableLiquidity.minus(balanceChange);
-  poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.minus(balanceChange);
+  poolReserve.availableLiquidity = poolReserve.availableLiquidity.minus(userBalanceChange);
+  poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.minus(userBalanceChange);
 
-  poolReserve.totalLiquidity = poolReserve.totalLiquidity.minus(balanceChange);
-  poolReserve.lifetimeWithdrawals = poolReserve.lifetimeWithdrawals.plus(balanceChange);
+  poolReserve.totalLiquidity = poolReserve.totalLiquidity.minus(userBalanceChange);
+  poolReserve.lifetimeWithdrawals = poolReserve.lifetimeWithdrawals.plus(userBalanceChange);
 
   if (userReserve.usageAsCollateralEnabledOnUser) {
     poolReserve.totalLiquidityAsCollateral =
-      poolReserve.totalLiquidityAsCollateral.minus(balanceChange);
+      poolReserve.totalLiquidityAsCollateral.minus(userBalanceChange);
   }
   saveReserve(poolReserve, event);
 
@@ -189,9 +189,9 @@ function tokenMint(
 ): void {
   let aToken = getOrInitSubToken(event.address);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
-  const balanceChange = value.minus(balanceIncrease);
+  const userBalanceChange = value.minus(balanceIncrease);
 
-  poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.plus(balanceChange);
+  poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.plus(userBalanceChange);
   let poolId = getPoolByContract(event);
   let pool = PoolSchema.load(poolId);
   if (pool && pool.pool) {
@@ -219,7 +219,7 @@ function tokenMint(
     onBehalf.toHexString() != '0x053D55f9B5AF8694c503EB288a1B7E552f590710'.toLowerCase()
   ) {
     let userReserve = getOrInitUserReserve(onBehalf, aToken.underlyingAssetAddress, event);
-    let calculatedAmount = rayDiv(balanceChange, index);
+    let calculatedAmount = rayDiv(userBalanceChange, index);
 
     userReserve.scaledATokenBalance = userReserve.scaledATokenBalance.plus(calculatedAmount);
     userReserve.currentATokenBalance = rayMul(userReserve.scaledATokenBalance, index);
@@ -231,24 +231,24 @@ function tokenMint(
     userReserve.save();
 
     // TODO: review
-    poolReserve.totalSupplies = poolReserve.totalSupplies.plus(balanceChange);
+    poolReserve.totalSupplies = poolReserve.totalSupplies.plus(userBalanceChange);
     // poolReserve.availableLiquidity = poolReserve.totalDeposits
     //   .minus(poolReserve.totalPrincipalStableDebt)
     //   .minus(poolReserve.totalScaledVariableDebt);
 
-    poolReserve.availableLiquidity = poolReserve.availableLiquidity.plus(balanceChange);
-    poolReserve.totalLiquidity = poolReserve.totalLiquidity.plus(balanceChange);
-    poolReserve.lifetimeLiquidity = poolReserve.lifetimeLiquidity.plus(balanceChange);
+    poolReserve.availableLiquidity = poolReserve.availableLiquidity.plus(userBalanceChange);
+    poolReserve.totalLiquidity = poolReserve.totalLiquidity.plus(userBalanceChange);
+    poolReserve.lifetimeLiquidity = poolReserve.lifetimeLiquidity.plus(userBalanceChange);
 
     if (userReserve.usageAsCollateralEnabledOnUser) {
       poolReserve.totalLiquidityAsCollateral =
-        poolReserve.totalLiquidityAsCollateral.plus(balanceChange);
+        poolReserve.totalLiquidityAsCollateral.plus(userBalanceChange);
     }
     saveReserve(poolReserve, event);
     saveUserReserveAHistory(userReserve, event, index);
   } else {
     poolReserve.lifetimeReserveFactorAccrued =
-      poolReserve.lifetimeReserveFactorAccrued.plus(balanceChange);
+      poolReserve.lifetimeReserveFactorAccrued.plus(userBalanceChange);
     saveReserve(poolReserve, event);
     // log.error('Minting to treasuey {} an amount of: {}', [from.toHexString(), value.toString()]);
   }
@@ -312,12 +312,12 @@ export function handleVariableTokenBurn(event: VTokenBurn): void {
   let from = event.params.from;
   let value = event.params.value;
   let balanceIncrease = event.params.balanceIncrease;
-  const balanceChange = value.plus(balanceIncrease);
+  const userBalanceChange = value.plus(balanceIncrease);
   let index = event.params.index;
   let userReserve = getOrInitUserReserve(from, vToken.underlyingAssetAddress, event);
   let poolReserve = getOrInitReserve(vToken.underlyingAssetAddress, event);
 
-  let calculatedAmount = rayDiv(balanceChange, index);
+  let calculatedAmount = rayDiv(userBalanceChange, index);
   userReserve.scaledVariableDebt = userReserve.scaledVariableDebt.minus(calculatedAmount);
   userReserve.currentVariableDebt = rayMul(userReserve.scaledVariableDebt, index);
   userReserve.currentTotalDebt = userReserve.currentStableDebt.plus(
@@ -330,8 +330,8 @@ export function handleVariableTokenBurn(event: VTokenBurn): void {
   //  value.minus(calculatedAmount)
   // );
 
-  poolReserve.availableLiquidity = poolReserve.availableLiquidity.plus(balanceChange);
-  poolReserve.lifetimeRepayments = poolReserve.lifetimeRepayments.plus(balanceChange);
+  poolReserve.availableLiquidity = poolReserve.availableLiquidity.plus(userBalanceChange);
+  poolReserve.lifetimeRepayments = poolReserve.lifetimeRepayments.plus(userBalanceChange);
 
   userReserve.liquidityRate = poolReserve.liquidityRate;
   userReserve.variableBorrowIndex = poolReserve.variableBorrowIndex;
@@ -359,7 +359,7 @@ export function handleVariableTokenMint(event: VTokenMint): void {
   let from = event.params.onBehalfOf;
   let value = event.params.value;
   const balanceIncrease = event.params.balanceIncrease;
-  const balanceChange = value.minus(balanceIncrease);
+  const userBalanceChange = value.minus(balanceIncrease);
   let index = event.params.index;
 
   let userReserve = getOrInitUserReserve(from, vToken.underlyingAssetAddress, event);
@@ -373,7 +373,7 @@ export function handleVariableTokenMint(event: VTokenMint): void {
     user.save();
   }
 
-  let calculatedAmount = rayDiv(balanceChange, index);
+  let calculatedAmount = rayDiv(userBalanceChange, index);
   userReserve.scaledVariableDebt = userReserve.scaledVariableDebt.plus(calculatedAmount);
   userReserve.currentVariableDebt = rayMul(userReserve.scaledVariableDebt, index);
 
@@ -393,8 +393,8 @@ export function handleVariableTokenMint(event: VTokenMint): void {
     poolReserve.lifetimeScaledVariableDebt.plus(calculatedAmount);
   poolReserve.lifetimeCurrentVariableDebt = rayMul(poolReserve.lifetimeScaledVariableDebt, index);
 
-  poolReserve.availableLiquidity = poolReserve.availableLiquidity.minus(balanceChange);
-  poolReserve.lifetimeBorrows = poolReserve.lifetimeBorrows.plus(balanceChange);
+  poolReserve.availableLiquidity = poolReserve.availableLiquidity.minus(userBalanceChange);
+  poolReserve.lifetimeBorrows = poolReserve.lifetimeBorrows.plus(userBalanceChange);
 
   saveReserve(poolReserve, event);
 


### PR DESCRIPTION
## TLDR
In v3, there are a bunch of wallets that have wrong balances in the subgraph compared to the on-chain data. 

## Example
For example, [0xbc1631afcb916bda28af42955fc970bf004596f8](https://polygonscan.com/address/0xbc1631afcb916bda28af42955fc970bf004596f8) on Polygon has 0 on-chain balance: 
![image](https://user-images.githubusercontent.com/17575462/187254021-5081b77e-02cc-4165-9984-4bdd35505f6e.png) but, querying this user from the subgraph and using [aave-utilities](https://github.com/aave/aave-utilities) formatter, the user has [balances](https://pastebin.com/crLMsxtT). 
Same goes for wallets that still have dust balance on chain: [0xee2826453a4fd5afeb7ceffeef3ffa2320081268](https://snowtrace.io/address/0xee2826453a4fd5afeb7ceffeef3ffa2320081268) on Avalanche : 0.00000018 WETH.e on chain- comparing to [1+ WETH.e](https://pastebin.com/4Z97fBe1) using the subgraph.

## Root cause - account balance computation updated in v3
It seems like the `Burn` and `Mint` events were changed in AAVE v3. In v3, The event value reports the amount that should be minted/burned while taking into account the interest which was accumulated (which impact the amount of mint/burned) since the last update. 
In v2, the events reported the amount which was supplied/withdrawn, and the interest could be calculated using other fields in the subgraph like `liquidityIndex`, `liquidityRate`, etc.


### Scope of Issue

- Any wallet that executed two actions with a delta such that interest was accrued stores the wrong balance.
    - For example, a wallet that has performed the `supply` method twice or a combination of `withdraw` and `supply`.
- This bug also affects any field that is affected by interest accumulated by the wallet balances. Namely, this effects Reserve metrics such as `totalSupply` and `totalBorrow` per asset.

### Impact

- This is a large-scale bug as it essentially affects all wallets (barring wallets that have only ever supplied).
- This means that anyone consuming data on wallets/health/risk from the officially supported subgraphs was reading the wrong data.
- Any teams, traders, or institutions attempting to make data-driven decisions based on subgraph data are affected.



## Proposed Fix
In order to keep consistency and backward compatibility to the structure of v2 (and to aave-utilities functions),  we need to sum up the `Burn.value` and `Burn.balanceIncrease` and use this value for all the calculations. The opposite goes for Mint - we need to subtract  `Mint.balanceIncrease` from `Mint.value`.


