### PR TITLE
fix: add missing abi

### DIFF
--- a/templates/matic.subgraph.template.yaml
+++ b/templates/matic.subgraph.template.yaml
@@ -89,6 +89,8 @@ dataSources:
           file: ./abis/v2/GenericOracleI.json
         - name: IExtendedPriceAggregator
           file: ./abis/helpers/IExtendedPriceAggregator.json
+        - name: EACAggregatorProxy
+          file: ./abis/helpers/EACAggregatorProxy.json
       eventHandlers:
         - event: AggregatorUpdated(address,address)
           handler: handleChainlinkAggregatorUpdated


### PR DESCRIPTION
`EACAggregatorProxy` needed to be added to `ChainlinkSourcesRegistry` contract abis in addition to `AaveOracle` to fix:

`{"data":{"indexingStatusForPendingVersion":{"subgraph":"QmfGNH6g9HK6vwbQtPmJDjxHLeDoWcCbPwinBWvtHToMTN","fatalError":{"message":"failed to process trigger: block #21442492 (0xf4f1…9a4e), transaction ae88916b2351855b6191486891cc6ab42857c83ed9ee43e9a1b7589a3c00363e: Could not find ABI for contract \"EACAggregatorProxy\", try adding it to the 'abis' section of the subgraph manifest\twasm backtrace:\t    0: 0x1d12 - <unknown>!~lib/@graphprotocol/graph-ts/chain/ethereum/ethereum.SmartContract#tryCall\t    1: 0x3d82 - <unknown>!src/mapping/proxy-price-provider/matic/priceFeedUpdated\t    2: 0x4638 - <unknown>!src/mapping/proxy-price-provider/matic/handleChainlinkAggregatorUpdated\t"},"nonFatalErrors":[]}}}`