### PR TITLE
fix: switch from composite to simple oracle on type revert

### DIFF
--- a/src/mapping/proxy-price-provider/ethereum.ts
+++ b/src/mapping/proxy-price-provider/ethereum.ts
@@ -68,13 +68,12 @@ export function priceFeedUpdated(
     let priceAggregatorInstance = IExtendedPriceAggregator.bind(assetOracleAddress);
 
     // check is it composite or simple asset.
-    // In case its chainlink source, this call will revert, and oracle type is updated to simple
-    // so it will stay as simple, as it is the default type
+    // In case its chainlink source, this call will revert, and oracle type is updated to simple, which is the default
     let tokenTypeCall = priceAggregatorInstance.try_getTokenType();
     if (!tokenTypeCall.reverted) {
       priceOracleAsset.type = getPriceOracleAssetType(tokenTypeCall.value);
     } else {
-      priceOracleAsset.type == PRICE_ORACLE_ASSET_TYPE_SIMPLE;
+      priceOracleAsset.type = PRICE_ORACLE_ASSET_TYPE_SIMPLE;
     }
 
     // Type simple means that the source is chainlink source
@@ -303,10 +302,13 @@ function chainLinkAggregatorUpdated(
   if (!assetOracleAddress.equals(zeroAddress())) {
     let priceAggregatorInstance = IExtendedPriceAggregator.bind(assetOracleAddress);
 
-    // // check is it composite or simple asset
+    // check is it composite or simple asset.
+    // In case its chainlink source, this call will revert, and oracle type is updated to simple, which is the default
     let tokenTypeCall = priceAggregatorInstance.try_getTokenType();
     if (!tokenTypeCall.reverted) {
       priceOracleAsset.type = getPriceOracleAssetType(tokenTypeCall.value);
+    } else {
+      priceOracleAsset.type = PRICE_ORACLE_ASSET_TYPE_SIMPLE;
     }
 
     if (priceOracleAsset.type == PRICE_ORACLE_ASSET_TYPE_SIMPLE) {

--- a/src/mapping/proxy-price-provider/ethereum.ts
+++ b/src/mapping/proxy-price-provider/ethereum.ts
@@ -73,6 +73,8 @@ export function priceFeedUpdated(
     let tokenTypeCall = priceAggregatorInstance.try_getTokenType();
     if (!tokenTypeCall.reverted) {
       priceOracleAsset.type = getPriceOracleAssetType(tokenTypeCall.value);
+    } else {
+      priceOracleAsset.type == PRICE_ORACLE_ASSET_TYPE_SIMPLE;
     }
 
     // Type simple means that the source is chainlink source

--- a/src/mapping/proxy-price-provider/ethereum.ts
+++ b/src/mapping/proxy-price-provider/ethereum.ts
@@ -68,7 +68,7 @@ export function priceFeedUpdated(
     let priceAggregatorInstance = IExtendedPriceAggregator.bind(assetOracleAddress);
 
     // check is it composite or simple asset.
-    // In case its chainlink source, this call will revert, and will not update priceOracleAsset type
+    // In case its chainlink source, this call will revert, and oracle type is updated to simple
     // so it will stay as simple, as it is the default type
     let tokenTypeCall = priceAggregatorInstance.try_getTokenType();
     if (!tokenTypeCall.reverted) {


### PR DESCRIPTION
Indexing error occurs here https://github.com/aave/protocol-subgraphs/blob/main/src/mapping/proxy-price-provider/ethereum.ts#L143. There's no logic to switch from a composite to a simple oracle, so it's attempting to run the composite logic on the new xsushi Chainlink aggregator and failing