### PR TITLE
fix: try parsing symbol as bytes on revert

### DIFF
--- a/src/mapping/lending-pool-configurator/v3.ts
+++ b/src/mapping/lending-pool-configurator/v3.ts
@@ -278,7 +278,17 @@ export function handleReserveInitialized(event: ReserveInitialized): void {
     reserve.name = nameStringCall.value;
   }
 
-  reserve.symbol = ERC20ReserveContract.symbol(); //.slice(1);
+  let symbolCall = ERC20ReserveContract.try_symbol();
+  if (symbolCall.reverted) {
+    let bytesSymbolCall = ERC20DetailedBytesContract.try_symbol();
+    if (bytesSymbolCall.reverted) {
+      reserve.symbol = '';
+    } else {
+      reserve.symbol = bytesSymbolCall.value.toString();
+    }
+  } else {
+    reserve.symbol = symbolCall.value;
+  }
 
   reserve.decimals = ERC20ReserveContract.decimals();
 


### PR DESCRIPTION
- The MKR erc20 contract `symbol` function return type is `bytes32`. This was failing because the expected return type was a `string`. This will handle the revert and try to get the symbol as `bytes32`. If that reverts, then it gets set to an empty string