### PR TITLE
fix: updated v3 schema for Pool entity

### DIFF
--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -19,6 +19,7 @@ type Pool @entity {
   poolCollateralManager: Bytes
   poolConfiguratorImpl: Bytes
   poolImpl: Bytes
+  poolDataProviderImpl: Bytes
   poolConfigurator: Bytes
   proxyPriceProvider: Bytes
   lastUpdateTimestamp: Int!


### PR DESCRIPTION
Fix: Add missing entity to Pool schema which causes indexing error on Protocol v3.0.2 update

Chore: Add Protocol v3.0.2 update blocks for Polygon, Optimism, and Arbitrum which changes parameters in BalanceTransfer event