### PR TITLE
fix: check block number for v3.0.1 upgrade

### DIFF
--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -197,6 +197,14 @@ export function getUpdateBlock(network: string): u32 {
   let updateBlock = -1;
   if (network === 'mainnet' || network === 'andromeda') {
     updateBlock = 0;
+  } else if (network === 'optimism') {
+    updateBlock = 775471;
+  } else if (network === 'polygon') {
+    updateBlock = 42535602;
+  } else if (network === 'arbitrum') {
+    updateBlock = 89267099;
+  } else if (network === 'avalanche') {
+    updateBlock = 29829396;
   }
 
   return updateBlock;

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -192,10 +192,16 @@ export function generateSymbol(description: string): string {
   return convertToLowerCase(symbolArr[0] + '-' + symbolArr[1]);
 }
 
-// returns block of market update to v3.0.1, or null if no upgrade
+/**
+ * Gets the block number at which the given market was updated to v3.0.1.
+ * Returns -1 if the market was not updated.
+ * @param network
+ * @returns block number
+ */
 export function getUpdateBlock(network: string): u32 {
   let updateBlock = -1;
   if (network === 'mainnet' || network === 'andromeda') {
+    // these markets were deployed with v3.0.1
     updateBlock = 0;
   } else if (network === 'optimism') {
     updateBlock = 775471;


### PR DESCRIPTION
- Adds in a check for when a market was upgraded to v3.0.1 so we can handle the balance transfer event correctly