### PR TITLE
fix: getUpdateBlock to handle BalancerTransfer event change

### DIFF
--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -150,8 +150,7 @@ function tokenBurn(
   let userReserve = getOrInitUserReserve(from, aToken.underlyingAssetAddress, event);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
 
-  // https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol#L116
-  const userBalanceChange = value.minus(balanceIncrease);
+  const userBalanceChange = value.plus(balanceIncrease);
   let calculatedAmount = rayDiv(userBalanceChange, index);
 
   userReserve.scaledATokenBalance = userReserve.scaledATokenBalance.minus(calculatedAmount);
@@ -193,8 +192,7 @@ function tokenMint(
   let aToken = getOrInitSubToken(event.address);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
 
-  // https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol#L83
-  const userBalanceChange = value.plus(balanceIncrease);
+  const userBalanceChange = value.minus(balanceIncrease);
 
   poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.plus(userBalanceChange);
   let poolId = getPoolByContract(event);

--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -283,7 +283,7 @@ export function handleBalanceTransfer(event: BalanceTransfer): void {
   let balanceTransferValue = event.params.value;
   const network = dataSource.network();
   const v301UpdateBlock = getUpdateBlock(network);
-  if (v301UpdateBlock !== -1 && event.block.number.toU32() > v301UpdateBlock) {
+  if (event.block.number.toU32() > v301UpdateBlock) {
     balanceTransferValue = balanceTransferValue.times(event.params.index);
   }
 

--- a/src/mapping/tokenization/tokenization-v3.ts
+++ b/src/mapping/tokenization/tokenization-v3.ts
@@ -150,7 +150,8 @@ function tokenBurn(
   let userReserve = getOrInitUserReserve(from, aToken.underlyingAssetAddress, event);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
 
-  const userBalanceChange = value.plus(balanceIncrease);
+  // https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol#L116
+  const userBalanceChange = value.minus(balanceIncrease);
   let calculatedAmount = rayDiv(userBalanceChange, index);
 
   userReserve.scaledATokenBalance = userReserve.scaledATokenBalance.minus(calculatedAmount);
@@ -191,7 +192,9 @@ function tokenMint(
 ): void {
   let aToken = getOrInitSubToken(event.address);
   let poolReserve = getOrInitReserve(aToken.underlyingAssetAddress, event);
-  const userBalanceChange = value.minus(balanceIncrease);
+
+  // https://github.com/aave/aave-v3-core/blob/724a9ef43adf139437ba87dcbab63462394d4601/contracts/protocol/tokenization/base/ScaledBalanceTokenBase.sol#L83
+  const userBalanceChange = value.plus(balanceIncrease);
 
   poolReserve.totalATokenSupply = poolReserve.totalATokenSupply.plus(userBalanceChange);
   let poolId = getPoolByContract(event);
@@ -219,7 +222,7 @@ function tokenMint(
     onBehalf.toHexString() != '0x5ba7fd868c40c16f7aDfAe6CF87121E13FC2F7a0'.toLowerCase() &&
     onBehalf.toHexString() != '0x8A020d92D6B119978582BE4d3EdFdC9F7b28BF31'.toLowerCase() &&
     onBehalf.toHexString() != '0x053D55f9B5AF8694c503EB288a1B7E552f590710'.toLowerCase() &&
-    onBehalf.toHexString() != '0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c'.toLowerCase() 
+    onBehalf.toHexString() != '0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c'.toLowerCase()
   ) {
     let userReserve = getOrInitUserReserve(onBehalf, aToken.underlyingAssetAddress, event);
     let calculatedAmount = rayDiv(userBalanceChange, index);
@@ -284,7 +287,7 @@ export function handleBalanceTransfer(event: BalanceTransfer): void {
   const network = dataSource.network();
   const v301UpdateBlock = getUpdateBlock(network);
   if (event.block.number.toU32() > v301UpdateBlock) {
-    balanceTransferValue = balanceTransferValue.times(event.params.index);
+    balanceTransferValue = rayMul(balanceTransferValue, event.params.index);
   }
 
   tokenBurn(event, event.params.from, balanceTransferValue, BigInt.fromI32(0), event.params.index);

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -193,17 +193,15 @@ export function generateSymbol(description: string): string {
 }
 
 /**
- * Gets the block number at which the given market was updated to v3.0.1.
- * Returns -1 if the market was not updated.
+ * Returns the block number at which the given market was updated to v3.0.1.
+ * This is needed due to an updated interpretation of `BalanceTransfer` events
+ * All market deployments not listed use updated version by default
  * @param network
  * @returns block number
  */
 export function getUpdateBlock(network: string): u32 {
-  let updateBlock = -1;
-  if (network === 'mainnet' || network === 'andromeda') {
-    // these markets were deployed with v3.0.1
-    updateBlock = 0;
-  } else if (network === 'optimism') {
+  let updateBlock = 0;
+  if (network === 'optimism') {
     updateBlock = 775471;
   } else if (network === 'polygon') {
     updateBlock = 42535602;


### PR DESCRIPTION
Fix incorrect logic in `getUpdateBlock` function used to detect if market is updated to v3.0.1 version and adjust interpretation of `BalanceTransfer` event

Preview deployment: https://subgraph.satsuma-prod.com/andrews-team--446278/protocol-v3-arbitrum/version/v0.0.1/api

Example Query: curl -v https://subgraph.satsuma-prod.com/47f735c94031/andrews-team--446278/protocol-v3-arbitrum/version/v0.0.1/api --data-raw '{"query":"{userReserves(where: { user: \"0x000169b8755138ca0a775d24ee23a5bb2a6eb607\"}){scaledATokenBalance}}"}'