### PR TITLE
fix: update existing emode if it exists

### DIFF
--- a/src/mapping/lending-pool-configurator/v3.ts
+++ b/src/mapping/lending-pool-configurator/v3.ts
@@ -274,17 +274,14 @@ export function handleEModeCategoryAdded(event: EModeCategoryAdded): void {
   let eModeCategory = EModeCategory.load(id);
   if (!eModeCategory) {
     eModeCategory = new EModeCategory(id);
-    eModeCategory.ltv = event.params.ltv;
-    eModeCategory.oracle = event.params.oracle;
-    eModeCategory.liquidationBonus = event.params.liquidationBonus;
-    eModeCategory.liquidationThreshold = event.params.liquidationThreshold;
-    eModeCategory.label = event.params.label;
-
-    eModeCategory.save();
-  } else {
-    log.error('Category with id: {} already existed', [id]);
-    return;
   }
+
+  eModeCategory.ltv = event.params.ltv;
+  eModeCategory.oracle = event.params.oracle;
+  eModeCategory.liquidationBonus = event.params.liquidationBonus;
+  eModeCategory.liquidationThreshold = event.params.liquidationThreshold;
+  eModeCategory.label = event.params.label;
+  eModeCategory.save();
 }
 
 export function handleDebtCeilingChanged(event: DebtCeilingChanged): void {


### PR DESCRIPTION
When an existing emode is updated, update the category parameters instead of throwing an error