### PR TITLE
feat: v3.2

### DIFF
--- a/abis/v3/Pool.json
+++ b/abis/v3/Pool.json
@@ -20,6 +20,19 @@
         {
           "indexed": true,
           "internalType": "address",
+          "name": "implementation",
+          "type": "address"
+        }
+      ],
+      "name": "Upgraded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
           "name": "reserve",
           "type": "address"
         },

--- a/abis/v3/PoolConfigurator.json
+++ b/abis/v3/PoolConfigurator.json
@@ -4,6 +4,56 @@
   "sourceName": "contracts/protocol/pool/PoolConfigurator.sol",
   "abi": [
     {
+      "type": "event",
+      "name": "AssetBorrowableInEModeChanged",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "categoryId",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "borrowable",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "AssetCollateralInEModeChanged",
+      "inputs": [
+        {
+          "name": "asset",
+          "type": "address",
+          "indexed": true,
+          "internalType": "address"
+        },
+        {
+          "name": "categoryId",
+          "type": "uint8",
+          "indexed": false,
+          "internalType": "uint8"
+        },
+        {
+          "name": "collateral",
+          "type": "bool",
+          "indexed": false,
+          "internalType": "bool"
+        }
+      ],
+      "anonymous": false
+    },
+    {
       "anonymous": false,
       "inputs": [
         {

--- a/schemas/v3.schema.graphql
+++ b/schemas/v3.schema.graphql
@@ -514,6 +514,7 @@ type EModeCategory @entity {
   liquidationBonus: BigInt!
   oracle: Bytes!
   label: String!
+  assets: [EModeCategoryConfig!] @derivedFrom(field: "category")
 }
 
 type MapAssetPool @entity {
@@ -793,4 +794,12 @@ type SwapHistory @entity {
   fromAmount: BigInt!
   receivedAmount: BigInt!
   swapType: String!
+}
+
+type EModeCategoryConfig @entity {
+  id: ID!
+  category: EModeCategory!
+  asset: Bytes!
+  collateral: Boolean!
+  borrowable: Boolean!
 }

--- a/src/mapping/lending-pool-configurator/v3.ts
+++ b/src/mapping/lending-pool-configurator/v3.ts
@@ -40,11 +40,13 @@ import {
   FlashloanPremiumTotalUpdated,
   FlashloanPremiumToProtocolUpdated,
   BorrowableInIsolationChanged,
+  AssetCollateralInEModeChanged,
+  AssetBorrowableInEModeChanged,
 } from '../../../generated/templates/PoolConfigurator/PoolConfigurator';
 import { DefaultReserveInterestRateStrategy } from '../../../generated/templates/PoolConfigurator/DefaultReserveInterestRateStrategy';
 import { DefaultReserveInterestRateStrategyV2 } from '../../../generated/templates/PoolConfigurator/DefaultReserveInterestRateStrategyV2';
 
-import { EModeCategory, Pool, Reserve } from '../../../generated/schema';
+import { EModeCategory, EModeCategoryConfig, Pool, Reserve } from '../../../generated/schema';
 import { zeroAddress, zeroBI } from '../../utils/converters';
 
 export function saveReserve(reserve: Reserve, event: ethereum.Event): void {
@@ -285,6 +287,48 @@ export function handleEModeCategoryAdded(event: EModeCategoryAdded): void {
     log.error('Category with id: {} already existed', [id]);
     return;
   }
+}
+
+export function handleAssetCollateralInEModeChanged(event: AssetCollateralInEModeChanged): void {
+  let id = BigInt.fromI32(event.params.categoryId).toString();
+  let eModeCategory = EModeCategory.load(id);
+  if (!eModeCategory) {
+    log.error('Emode category with id: {} does not exist', [id]);
+    return;
+  }
+
+  let configId = event.params.asset.toHexString().concat(id);
+  let config = EModeCategoryConfig.load(configId);
+  if (!config) {
+    config = new EModeCategoryConfig(configId);
+  }
+
+  config.category = id;
+  config.asset = event.params.asset;
+  config.collateral = event.params.collateral;
+
+  config.save();
+}
+
+export function handleAssetBorrowableInEModeChanged(event: AssetBorrowableInEModeChanged): void {
+  let id = BigInt.fromI32(event.params.categoryId).toString();
+  let eModeCategory = EModeCategory.load(id);
+  if (!eModeCategory) {
+    log.error('Emode category with id: {} does not exist', [id]);
+    return;
+  }
+
+  let configId = event.params.asset.toHexString().concat(id);
+  let config = EModeCategoryConfig.load(configId);
+  if (!config) {
+    config = new EModeCategoryConfig(configId);
+  }
+
+  config.category = id;
+  config.asset = event.params.asset;
+  config.borrowable = event.params.borrowable;
+
+  config.save();
 }
 
 export function handleDebtCeilingChanged(event: DebtCeilingChanged): void {

--- a/src/mapping/lending-pool-configurator/v3.ts
+++ b/src/mapping/lending-pool-configurator/v3.ts
@@ -298,6 +298,7 @@ export function handleAssetCollateralInEModeChanged(event: AssetCollateralInEMod
   let config = EModeCategoryConfig.load(configId);
   if (!config) {
     config = new EModeCategoryConfig(configId);
+    config.borrowable = false;
   }
 
   config.category = id;
@@ -319,6 +320,7 @@ export function handleAssetBorrowableInEModeChanged(event: AssetBorrowableInEMod
   let config = EModeCategoryConfig.load(configId);
   if (!config) {
     config = new EModeCategoryConfig(configId);
+    config.collateral = false;
   }
 
   config.category = id;

--- a/templates/v3-gho.subgraph.template.yaml
+++ b/templates/v3-gho.subgraph.template.yaml
@@ -133,7 +133,7 @@ dataSources:
         - event: EmissionManagerUpdated(indexed address,indexed address)
           handler: handleEmissionManagerUpdated
       file: src/mapping/incentives-controller/v3.ts
-    
+
   - kind: ethereum/contract
     name: GhoToken
     network: {{network}}
@@ -473,6 +473,10 @@ templates:
           handler: handleEModeAssetCategoryChanged
         - event: EModeCategoryAdded(indexed uint8,uint256,uint256,uint256,address,string)
           handler: handleEModeCategoryAdded
+        - event: AssetCollateralInEModeChanged(indexed address,uint8,bool)
+          handler: handleAssetCollateralInEModeChanged
+        - event: AssetBorrowableInEModeChanged(indexed address,uint8,bool)
+          handler: handleAssetBorrowableInEModeChanged
         - event: FlashloanPremiumToProtocolUpdated(uint128,uint128)
           handler: handleFlashloanPremiumToProtocolUpdated
         - event: FlashloanPremiumTotalUpdated(uint128,uint128)

--- a/templates/v3.subgraph.template.yaml
+++ b/templates/v3.subgraph.template.yaml
@@ -378,6 +378,10 @@ templates:
           handler: handleEModeAssetCategoryChanged
         - event: EModeCategoryAdded(indexed uint8,uint256,uint256,uint256,address,string)
           handler: handleEModeCategoryAdded
+        - event: AssetCollateralInEModeChanged(indexed address,uint8,bool)
+          handler: handleAssetCollateralInEModeChanged
+        - event: AssetBorrowableInEModeChanged(indexed address,uint8,bool)
+          handler: handleAssetBorrowableInEModeChanged
         - event: FlashloanPremiumToProtocolUpdated(uint128,uint128)
           handler: handleFlashloanPremiumToProtocolUpdated
         - event: FlashloanPremiumTotalUpdated(uint128,uint128)


### PR DESCRIPTION
- Adds in support for new Liquid EModes that was added in v3.2. There's a new emode config entity to track an emode's category asset and if it can be collateral and/or borrowable.
- Updated the pool abi to include the 'Upgraded' event, in case we want to use it to track protocol upgrades in the future.